### PR TITLE
Added missing effect id.

### DIFF
--- a/src/Lib/General/effects.ts
+++ b/src/Lib/General/effects.ts
@@ -28,4 +28,5 @@ export const Effects: string[] = [
   "slow_falling",
   "bad_omen",
   "village_hero",
+  "darkness"
 ];


### PR DESCRIPTION
Added missing effect id for Minecraft Bedrock for the darkness effect that was added this is used by the warden.